### PR TITLE
Fix css loaders in webpack bundle config.

### DIFF
--- a/bundle.js
+++ b/bundle.js
@@ -73,7 +73,12 @@ async function bundle(configuration) {
                 },
                 {
                     test: /\.scss$/,
-                    use: ['style-loader', MiniCssExtractPlugin.loader, 'css-loader', 'sass-loader']
+                    use: [
+                        path.resolve(__dirname, 'node_modules', 'style-loader'),
+                        MiniCssExtractPlugin.loader,
+                        path.resolve(__dirname, 'node_modules', 'css-loader'),
+                        path.resolve(__dirname, 'node_modules', 'sass-loader')
+                    ]
                 },
                 {
                     test: /.*\.html$/,
@@ -111,7 +116,7 @@ async function bundle(configuration) {
     }
 
     return new Promise((resolve, reject) => {
-        if (Object.keys(config.entry).length == 0) {
+        if (Object.keys(config.entry).length === 0) {
             logger.info('Skipping webpack bundle');
             resolve();
         } else {

--- a/bundle.js
+++ b/bundle.js
@@ -1,9 +1,7 @@
 const webpack = require('webpack');
 const WebpackBar = require('webpackbar');
 const CleanWebpackPlugin = require('clean-webpack-plugin');
-const MiniCssExtractPlugin = require("mini-css-extract-plugin");
 const path = require('path');
-
 const logger = require('./logger');
 
 async function bundle(configuration) {
@@ -37,10 +35,7 @@ async function bundle(configuration) {
                 exclude: [],
                 watch: false
             }),
-            new WebpackBar(),
-            new MiniCssExtractPlugin({
-                filename: 'panel.css',
-            }),
+            new WebpackBar()
         ],
         module: {
             rules: [
@@ -75,7 +70,6 @@ async function bundle(configuration) {
                     test: /\.scss$/,
                     use: [
                         path.resolve(__dirname, 'node_modules', 'style-loader'),
-                        MiniCssExtractPlugin.loader,
                         path.resolve(__dirname, 'node_modules', 'css-loader'),
                         path.resolve(__dirname, 'node_modules', 'sass-loader')
                     ]


### PR DESCRIPTION
Webpack was unable to find the css loaders without use specifying exactly where they are. This also removes the plugin that creates a separate css file out of it so that the styles are bundled into the templates directly.